### PR TITLE
Feat: option to override stream opts

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,8 @@ async function query (receiver) {
 
 async function pay (plugin, {
   receiver,
-  sourceAmount
+  sourceAmount,
+  streamOpts = {}
   // TODO: do we need destinationAmount?
   // TODO: do we need application data?
 }) {
@@ -73,7 +74,8 @@ async function pay (plugin, {
     const ilpConn = await createConnection({
       plugin,
       destinationAccount: response.destinationAccount,
-      sharedSecret: response.sharedSecret
+      sharedSecret: response.sharedSecret,
+      ...streamOpts
     })
 
     const payStream = ilpConn.createStream()

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.19"
+        "iconv-lite": "~0.4.13"
       }
     },
     "extensible-error": {
@@ -50,10 +50,10 @@
       "resolved": "https://registry.npmjs.org/ilp-compat-plugin/-/ilp-compat-plugin-2.0.3.tgz",
       "integrity": "sha512-enMMJJ4T6Q0+GWbyov2Oe/14ikEgmy6feMWGOrXpUy1NtFLskDPGL+GKFG7kJNq5OlqHUz1SUqU224odOE65Cg==",
       "requires": {
-        "debug": "3.1.0",
-        "ilp-packet": "2.2.0",
-        "oer-utils": "1.3.4",
-        "uuid": "3.3.2"
+        "debug": "^3.1.0",
+        "ilp-packet": "^2.1.0",
+        "oer-utils": "^1.3.4",
+        "uuid": "^3.1.0"
       },
       "dependencies": {
         "oer-utils": {
@@ -68,10 +68,10 @@
       "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-2.2.0.tgz",
       "integrity": "sha1-qHJcwmMxxuLGU1OKEGPVUBQwXjE=",
       "requires": {
-        "bignumber.js": "5.0.0",
-        "extensible-error": "1.0.2",
-        "long": "3.2.0",
-        "oer-utils": "1.3.4"
+        "bignumber.js": "^5.0.0",
+        "extensible-error": "^1.0.2",
+        "long": "^3.2.0",
+        "oer-utils": "^1.3.2"
       },
       "dependencies": {
         "bignumber.js": {
@@ -91,8 +91,8 @@
       "resolved": "https://registry.npmjs.org/ilp-protocol-ildcp/-/ilp-protocol-ildcp-1.0.0.tgz",
       "integrity": "sha512-rmmrnwUKyVYHwJyteYMF6R6dO6ap1j6c7uNDiCqNLPXQSuNQUwAdXd+7CfStED/mOcM/D86IEZrcNx35GtCt6Q==",
       "requires": {
-        "ilp-packet": "2.2.0",
-        "oer-utils": "1.3.4"
+        "ilp-packet": "^2.1.2",
+        "oer-utils": "^1.3.4"
       },
       "dependencies": {
         "oer-utils": {
@@ -107,13 +107,13 @@
       "resolved": "https://registry.npmjs.org/ilp-protocol-psk2/-/ilp-protocol-psk2-0.5.0.tgz",
       "integrity": "sha512-VwxNI7ZpVLv7LKLrTnxVJxnq3WBgzX/TdJNc72RqoCU1jpo+hD0L1DKY4pGTr96bLfuZCAb7gi9ZySohwC1jeA==",
       "requires": {
-        "bignumber.js": "5.0.0",
-        "debug": "3.1.0",
-        "ilp-compat-plugin": "2.0.3",
-        "ilp-packet": "2.2.0",
-        "ilp-protocol-ildcp": "1.0.0",
-        "long": "3.2.0",
-        "oer-utils": "1.3.4"
+        "bignumber.js": "^5.0.0",
+        "debug": "^3.1.0",
+        "ilp-compat-plugin": "^2.0.3",
+        "ilp-packet": "^2.1.2",
+        "ilp-protocol-ildcp": "^1.0.0",
+        "long": "^3.2.0",
+        "oer-utils": "^1.3.2"
       },
       "dependencies": {
         "bignumber.js": {
@@ -133,13 +133,13 @@
       "resolved": "https://registry.npmjs.org/ilp-protocol-stream/-/ilp-protocol-stream-1.3.2.tgz",
       "integrity": "sha512-7RHwdKFJgi7ZgapK8poN5KW2zoYmLrEc0AZJUgK8+YqiU4Xlqvfgmf/w3Gp7mGh182+8NIFpvO+ZdEpcpU35Pg==",
       "requires": {
-        "@types/node": "9.6.22",
-        "bignumber.js": "6.0.0",
-        "debug": "3.1.0",
-        "ilp-packet": "2.2.0",
-        "ilp-protocol-ildcp": "1.0.0",
-        "oer-utils": "2.0.1",
-        "source-map-support": "0.5.6"
+        "@types/node": "^9.6.17",
+        "bignumber.js": "^6.0.0",
+        "debug": "^3.1.0",
+        "ilp-packet": "^2.2.0",
+        "ilp-protocol-ildcp": "^1.0.0",
+        "oer-utils": "^2.0.1",
+        "source-map-support": "^0.5.6"
       }
     },
     "is-stream": {
@@ -167,8 +167,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "oer-utils": {
@@ -176,7 +176,7 @@
       "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-2.0.1.tgz",
       "integrity": "sha512-9m3lctkkc/hofsfw76ZQrsIQmenQcC8MggqRP3aPdImYBObywZUCIEXcXAzekas5UpwMAdy7WT0/aHLoDo8PcQ==",
       "requires": {
-        "bignumber.js": "6.0.0"
+        "bignumber.js": "^6.0.0"
       }
     },
     "source-map": {
@@ -189,8 +189,8 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
       "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
       "requires": {
-        "buffer-from": "1.1.0",
-        "source-map": "0.6.1"
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "uuid": {


### PR DESCRIPTION
I need this so I can set the min precision lower (on the current network we want a min precision of 2 instead of the default of 3; many STREAM connections go from a scale 9 node to a scale 6 one)